### PR TITLE
Add objectSizeBytes config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
-## Unreleased
+## v0.0.6
+
+### Added
+
+- [BREAKING] [[#2](https://github.com/kislerdm/object-storage-gateway/issues/2)] The configuration `objectSizeBytes` was added as the 
+attribute of the `Gateway`'s `Write` method. The change enables to reduce memory consumption significantly: 
+execution of the use case described in the [issue](https://github.com/kislerdm/object-storage-gateway/issues/2) will require ~10MiB of RAM instead of ~1GiB.
+
+---
+**Note** that `objectSizeBytes` can be set to `-1` when the object size is unknown. 
+However, it will result in a greedy memory allocation strategy identical to the one used in the previous releases.
+---
 
 ### v0.0.5
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ classDiagram
        +Logger *slog.Logger
 
       +Read(ctx context.Context, id string) io.ReadCloser, bool, error
-      +Write(ctx context.Context, id string, reader io.Reader) error
+      +Write(ctx context.Context, id string, reader io.Reader, objectSizeBytes int64) error
   }
 
   class StorageConnectionReadFinder {
@@ -123,7 +123,7 @@ classDiagram
       // pkg/gateway/gateway.go
       <<interface>>
       Read(ctx context.Context, bucketName, objectName string) io.ReadCloser, bool, error
-      Write(ctx context.Context, bucketName, objectName string, reader io.Reader) error
+      Write(ctx context.Context, bucketName, objectName string, reader io.Reader, objectSizeBytes int64) error
       Find(ctx context.Context, bucketName, objectName string) bool, error
   }
 

--- a/internal/minio/minio.go
+++ b/internal/minio/minio.go
@@ -46,7 +46,7 @@ func (c *Client) Read(ctx context.Context, bucketName, objectName string) (io.Re
 	return reader, true, nil
 }
 
-func (c *Client) Write(ctx context.Context, bucketName, objectName string, reader io.Reader) error {
+func (c *Client) Write(ctx context.Context, bucketName, objectName string, reader io.Reader, objectSizeBytes int64) error {
 	exists, err := c.BucketExists(ctx, bucketName)
 	if err != nil {
 		return fmt.Errorf("cannot store the object: %w", err)
@@ -57,7 +57,7 @@ func (c *Client) Write(ctx context.Context, bucketName, objectName string, reade
 		}
 	}
 
-	_, err = c.PutObject(ctx, bucketName, objectName, reader, -1, minio.PutObjectOptions{})
+	_, err = c.PutObject(ctx, bucketName, objectName, reader, objectSizeBytes, minio.PutObjectOptions{})
 	return err
 }
 

--- a/internal/restfulhandler/handler_test.go
+++ b/internal/restfulhandler/handler_test.go
@@ -42,7 +42,7 @@ func (m *mockReadWriter) Read(_ context.Context, _ string) (readCloser io.ReadCl
 	return io.NopCloser(m.readCloser), m.readCloser != nil, nil
 }
 
-func (m *mockReadWriter) Write(_ context.Context, _ string, reader io.Reader) error {
+func (m *mockReadWriter) Write(_ context.Context, _ string, reader io.Reader, _ int64) error {
 	if m.err != nil {
 		return m.err
 	}

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -115,7 +115,7 @@ func (s *Gateway) Read(ctx context.Context, id string) (io.ReadCloser, bool, err
 }
 
 // Write writes object to the storage.
-func (s *Gateway) Write(ctx context.Context, id string, reader io.Reader) error {
+func (s *Gateway) Write(ctx context.Context, id string, reader io.Reader, objectSizeBytes int64) error {
 	instances, err := s.storageDiscoveryClient.Find(ctx, s.storageInstancesSelector)
 	if err != nil {
 		return err
@@ -153,7 +153,7 @@ func (s *Gateway) Write(ctx context.Context, id string, reader io.Reader) error 
 				slog.String("objectID", id),
 			)
 
-			return conn.Write(ctx, s.storageBucket, id, reader)
+			return conn.Write(ctx, s.storageBucket, id, reader, objectSizeBytes)
 		}
 	}
 
@@ -171,7 +171,7 @@ func (s *Gateway) Write(ctx context.Context, id string, reader io.Reader) error 
 		slog.String("objectID", id),
 	)
 
-	return conn.Write(ctx, s.storageBucket, id, reader)
+	return conn.Write(ctx, s.storageBucket, id, reader, objectSizeBytes)
 }
 
 func (s *Gateway) newStorageInstanceConnection(ctx context.Context, id string) (ObjectReadWriteFinder, error) {
@@ -233,7 +233,7 @@ type ObjectReadWriteFinder interface {
 	Read(ctx context.Context, bucketName, objectName string) (io.ReadCloser, bool, error)
 
 	// Write writes the object.
-	Write(ctx context.Context, bucketName, objectName string, reader io.Reader) error
+	Write(ctx context.Context, bucketName, objectName string, reader io.Reader, objectSizeBytes int64) error
 
 	// Find identifies if the object can be found in the instance.
 	Find(ctx context.Context, bucketName, objectName string) (bool, error)

--- a/pkg/gateway/gateway_test.go
+++ b/pkg/gateway/gateway_test.go
@@ -103,7 +103,7 @@ func TestGateway_Write(t *testing.T) {
 		gateway.newStorageConnectionFn = mockMinioConnectionFactory(nil, &mockStorageClient{dataReader: inputData})
 
 		// WHEN
-		err := gateway.Write(context.TODO(), inputID, inputData)
+		err := gateway.Write(context.TODO(), inputID, inputData, -1)
 
 		// THEN
 		if err != nil {
@@ -117,7 +117,7 @@ func TestGateway_Write(t *testing.T) {
 		gateway.newStorageConnectionFn = mockMinioConnectionFactory(nil, &mockStorageClient{})
 
 		// WHEN
-		err := gateway.Write(context.TODO(), inputID, inputData)
+		err := gateway.Write(context.TODO(), inputID, inputData, -1)
 
 		// THEN
 		if err != nil {
@@ -148,7 +148,7 @@ func (m *mockStorageClient) Read(_ context.Context, _, _ string) (io.ReadCloser,
 	return io.NopCloser(m.dataReader), m.dataReader != nil, nil
 }
 
-func (m *mockStorageClient) Write(_ context.Context, _, _ string, reader io.Reader) error {
+func (m *mockStorageClient) Write(_ context.Context, _, _ string, reader io.Reader, _ int64) error {
 	if m.err != nil {
 		return m.err
 	}


### PR DESCRIPTION
resolves #2 

## Why changed

- Added `objectSizeBytes` as the argument of the `Write` method

## Why do we need it

- To optimise the memory consumption

